### PR TITLE
Resolve Race Conditions

### DIFF
--- a/.github/workflows/python-versions-test.yml
+++ b/.github/workflows/python-versions-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ coverage.json
 venv
 .venv
 /.idea/modules.xml
+logs
+uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,14 @@ dist/
 build/
 *.egg-info/
 
+# test coverage files
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+coverage.json
+.pytest_cache/
+
 venv
+.venv
 /.idea/modules.xml

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-Copyright (c) 2024-2025, Alex Plakantonakis.
+Copyright (c) 2024-2026, Alex Plakantonakis.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # AbStochKin: Agent-based Stochastic Kinetics
+
 <p>
   <a href="https://doi.org/10.5281/zenodo.14255157">
     <img src="https://zenodo.org/badge/733779271.svg" alt="DOI">
@@ -23,56 +24,56 @@
 
 ##### Alternate name: PyStochKin (Particle-based Stochastic Kinetics)
 
-`AbStochKin` is an agent-based (or particle-based) Monte-Carlo simulator of the time 
-evolution of systems composed of species that participate in coupled processes. 
-The population of a species is considered as composed of distinct individuals, 
-termed *agents*, or *particles*. 
-This allows for the specification of the kinetic parameters describing 
-the propensity of *each agent* to participate in a given process. 
+`AbStochKin` is an agent-based (or particle-based) Monte-Carlo simulator of the time
+evolution of systems composed of species that participate in coupled processes.
+The population of a species is considered as composed of distinct individuals,
+termed *agents*, or *particles*.
+This allows for the specification of the kinetic parameters describing
+the propensity of *each agent* to participate in a given process.
 
-Although the algorithm was originally conceived for simulating biochemical 
-systems, it is applicable to other disciplines where there is a need to model 
-how populations change over time and to study the effects of heterogeneity, 
+Although the algorithm was originally conceived for simulating biochemical
+systems, it is applicable to other disciplines where there is a need to model
+how populations change over time and to study the effects of heterogeneity,
 or diversity, in the composition of species populations on the dynamics of a system.
 
 ## Installation
-The `abstochkin` package can be installed via `pip` in an environment with 
-Python 3.12+. 
-```
-$ pip install abstochkin 
-```
-For an overview of installing packages in Python, see the 
-[Python packaging user guide](https://packaging.python.org/en/latest/tutorials/installing-packages/).
+
+The `abstochkin` package can be installed via `pip` in an environment with Python 3.12+.
+
+`$ pip install abstochkin`
 
 ### Requirements
-The package relies only on Python's scientific ecosystem 
-libraries (`numpy`, `scipy`, `sympy`, `matplotlib`) and 
-the standard library for implementing the core components of the algorithm. 
+
+The package relies only on Python's scientific ecosystem
+libraries (`numpy`, `scipy`, `sympy`, `matplotlib`) and
+the standard library for implementing the core components of the algorithm.
 These requirements can be easily met in any Python (version 3.12+) environment.
 
 ## What processes can be modeled?
+
 - Simple processes (0th, 1st, 2nd order).
 - Processes obeying Michaelis-Menten kinetics (1st order).
 - Processes that are regulated by one or more species through activation or repression (0th, 1st, 2nd order).
 - Processes that are regulated *and* obey Michaelis-Menten kinetics (1st order).
 
 ## Usage
-Here is a simple example of how to run a simulation: consider the process 
-$A \rightarrow B$, the conversion of agents of species $A$ to agents of species $B$. 
-Notice that we represent the process in standard chemical notation, therefore 
-there are 'reactants' and 'products' and each species has a stoichiometric 
-coefficient associated with it (implied to be $1$ if it is not explicitly written). 
-The rate constant for this process is specified to be $k=0.2$ and has units of 
-reciprocal seconds. Here, we assume a homogeneous population; that is, all 
-agents of species $A$ have the same propensity to 'transition' to species $B$. 
-Thus, the value $k=0.2$ applies to all $A$ agents when determining the transition 
+
+Here is a simple example of how to run a simulation: consider the process
+$A \rightarrow B$, the conversion of agents of species $A$ to agents of species $B$.
+Notice that we represent the process in standard chemical notation, therefore
+there are 'reactants' and 'products' and each species has a stoichiometric
+coefficient associated with it (implied to be $1$ if it is not explicitly written).
+The rate constant for this process is specified to be $k=0.2$ and has units of
+reciprocal seconds. Here, we assume a homogeneous population; that is, all
+agents of species $A$ have the same propensity to 'transition' to species $B$.
+Thus, the value $k=0.2$ applies to all $A$ agents when determining the transition
 probability within a given time step.
 
-We then run an ensemble of simulations by specifying the initial population 
-sizes ($A$: $100$ agents, $B$: $0$ agents) and the simulated time of $10$ seconds. 
+We then run an ensemble of simulations by specifying the initial population
+sizes ($A$: $100$ agents, $B$: $0$ agents) and the simulated time of $10$ seconds.
 Behind the scenes, default values for unspecified but necessary arguments are used
-(specifically, the number of simulations that comprise the ensemble, $n=100$, 
-and the duration of the fixed time interval for each step in the simulation, 
+(specifically, the number of simulations that comprise the ensemble, $n=100$,
+and the duration of the fixed time interval for each step in the simulation,
 $dt=0.01$ seconds).
 
 ```python
@@ -82,22 +83,25 @@ sim = AbStochKin()
 sim.add_process_from_str('A -> B', k=0.2)
 sim.simulate(p0={'A': 100, 'B': 0}, t_max=10)
 ```
+
 When the simulation is completed, the results are presented in graphical form.
 
 ## Concurrency
-The algorithm performs an ensemble of simulations to obtain the mean time 
-trajectory of all species and statistical measures of the uncertainty thereof. 
-To facilitate the rapid execution of the simulation, *multithreading* is enabled 
-by default. This is done because `numpy`, whose core algorithms can bypass 
-the Global Interpreter Lock (GIL), is used extensively during the algorithm's 
-runtime. For instance, the simple usage example presented above uses 
+
+The algorithm performs an ensemble of simulations to obtain the mean time
+trajectory of all species and statistical measures of the uncertainty thereof.
+To facilitate the rapid execution of the simulation, *multithreading* is enabled
+by default. This is done because `numpy`, whose core algorithms can bypass
+the Global Interpreter Lock (GIL), is used extensively during the algorithm's
+runtime. For instance, the simple usage example presented above uses
 multithreading.
 
-When running a series of jobs (each with its own ensemble of simulations) 
-where a parameter is varied (e.g., a parameter sweep), *process-based 
-parallellism* can be used. The user does not have to worry about 
-the details of setting up the code for multiprocessing. Instead, they can simply 
+When running a series of jobs (each with its own ensemble of simulations)
+where a parameter is varied (e.g., a parameter sweep), *process-based
+parallellism* can be used. The user does not have to worry about
+the details of setting up the code for multiprocessing. Instead, they can simply
 call a method of the base class.
+
 ```python
 from abstochkin import AbStochKin
 
@@ -110,14 +114,16 @@ sim.simulate_series_in_parallel(series_kwargs)
 ```
 
 ## Documentation
+
 See the documentation [here](https://alexplaka.github.io/AbStochKin).
 
-A monograph detailing the theoretical underpinnings of the *Agent-based Kinetics* 
-algorithm and a multitude of case studies highlighting its use can be found 
+A monograph detailing the theoretical underpinnings of the *Agent-based Kinetics*
+algorithm and a multitude of case studies highlighting its use can be found
 [here](/docs/Agent-basedKinetics_monograph.pdf).
 
 ## Contributing
-We welcome any contributions to the project in the form of bug reports, 
-feature requests, and pull requests. Feel free to contact the core developer 
-and maintainer at alex dot plaka at alumni dot princeton.edu to introduce 
+
+We welcome any contributions to the project in the form of bug reports,
+feature requests, and pull requests. Feel free to contact the core developer
+and maintainer at alex dot plaka at alumni dot princeton.edu to introduce
 yourself and discuss possible ways to contribute.

--- a/abstochkin/__init__.py
+++ b/abstochkin/__init__.py
@@ -1,6 +1,6 @@
 """ Agent-based (or Particle-based) Stochastic Kinetics. """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/abstochkin/_simulation_methods.py
+++ b/abstochkin/_simulation_methods.py
@@ -919,14 +919,14 @@ class SimulationMethodsMixin:
 
         self.progress_bar.update(1)
 
-    def _order_0(self, proc: Process, r: int, t: int):
+    def _order_0(self, proc: Process, r: int, t: int, transition_p: float = None):
         """
-        Determine the transition probability for a 0th order process `proc`
-        in a single time step of an AbStochKin simulation and assess if a
-        transition event occurs. Then update the agent-state vector
+        Assess if a transition event occurs. Then update the agent-state vector
         `asv` accordingly.
         """
-        if self.streams[r].random() < self.trans_p[proc]:
+        trans_p = transition_p if transition_p is not None else self.trans_p[proc]
+
+        if self.streams[r].random() < trans_p:
             available_agent = np.argmin(self.rtd[proc.prods_[0]].asv[r][0])
             self.rtd[proc.prods_[0]].asv[r][1, available_agent] = 1
 
@@ -939,9 +939,9 @@ class SimulationMethodsMixin:
         ratio = self.results[proc.regulating_species]['N'][t - 1, r] / proc.K50
         mult = (1 + proc.alpha * ratio ** proc.nH) / (1 + ratio ** proc.nH)
 
-        self.trans_p[proc] = proc.k * mult * self.dt
+        transition_probability = proc.k * mult * self.dt
 
-        self._order_0(proc, r, t)
+        self._order_0(proc, r, t, transition_probability)
 
     def _order_0_reg_gt1(self, proc: RegulatedProcess, r: int, t: int):
         """
@@ -954,20 +954,22 @@ class SimulationMethodsMixin:
             ratio = self.results[sp]['N'][t - 1, r] / proc.K50[i]
             mult *= (1 + proc.alpha[i] * ratio ** proc.nH[i]) / (1 + ratio ** proc.nH[i])
 
-        self.trans_p[proc] = proc.k * mult * self.dt
+        transition_probability = proc.k * mult * self.dt
 
-        self._order_0(proc, r, t)
+        self._order_0(proc, r, t, transition_probability)
 
-    def _order_1(self, proc: Process, r: int, t: int):
+    def _order_1(self, proc: Process, r: int, t: int, transition_p: np.ndarray = None):
         """
         Determine the transition events for a 1st order process `proc`
         in a single time step of an AbStochKin simulation. Then update the
         agent-state vector `asv` accordingly.
         """
+        trans_p = transition_p if transition_p is not None else self.trans_p[proc]
+
         # Get random numbers (rn) and transition probabilities (tp)
         rn, tp = self.rtd[proc.reacts_[0]].get_vals_o1(r,
                                                        self.streams[r],
-                                                       self.trans_p[proc])
+                                                       trans_p)
 
         transition_events = rn < tp  # Determine all transition events in this time step
 
@@ -993,9 +995,10 @@ class SimulationMethodsMixin:
         """
         mult = self.results[proc.catalyst]['N'][t - 1, r] / (
                 self.results[proc.reacts_[0]]['N'][t - 1, r] + self.Km_vals[proc])
-        self.trans_p[proc] = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
 
-        self._order_1(proc, r, t)
+        transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
+
+        self._order_1(proc, r, t, transition_probability)
 
         if proc.is_heterogeneous_Km:  # Now compute metrics of heterogeneity (Km)
             new_Km_vals = self.Km_vals[proc] * (self.rtd[proc.reacts_[0]].asv[r][1, :] > 0)
@@ -1009,8 +1012,9 @@ class SimulationMethodsMixin:
         """
         ratio = self.results[proc.regulating_species]['N'][t - 1, r] / self.K50_vals[proc]
         mult = (1 + proc.alpha * ratio ** proc.nH) / (1 + ratio ** proc.nH)
-        self.trans_p[proc] = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
-        self._order_1(proc, r, t)
+        transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
+
+        self._order_1(proc, r, t, transition_probability)
 
         if proc.is_heterogeneous_K50:  # Now compute metrics of heterogeneity (K50)
             new_K50_vals = self.K50_vals[proc] * (self.rtd[proc.reacts_[0]].asv[r][1, :] > 0)
@@ -1026,8 +1030,9 @@ class SimulationMethodsMixin:
         for i, sp in enumerate(proc.regulating_species):
             ratio = self.results[sp]['N'][t - 1, r] / self.K50_vals[proc][i]
             mult *= (1 + proc.alpha[i] * ratio ** proc.nH[i]) / (1 + ratio ** proc.nH[i])
-        self.trans_p[proc] = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
-        self._order_1(proc, r, t)
+        transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
+
+        self._order_1(proc, r, t, transition_probability)
 
         for i in range(len(proc.regulating_species)):
             if proc.is_heterogeneous_K50[i]:  # Now compute metrics of heterogeneity (K50)
@@ -1046,8 +1051,9 @@ class SimulationMethodsMixin:
         mult_mm = self.results[proc.catalyst]['N'][t - 1, r] / (
                 self.results[proc.reacts_[0]]['N'][t - 1, r] + self.Km_vals[proc])
         mult = mult_reg * mult_mm
-        self.trans_p[proc] = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
-        self._order_1(proc, r, t)
+        transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
+
+        self._order_1(proc, r, t, transition_probability)
 
         if proc.is_heterogeneous_K50:  # Now compute metrics of heterogeneity (K50)
             new_K50_vals = self.K50_vals[proc] * (self.rtd[proc.reacts_[0]].asv[r][1, :] > 0)
@@ -1071,8 +1077,9 @@ class SimulationMethodsMixin:
         mult_mm = self.results[proc.catalyst]['N'][t - 1, r] / (
                 self.results[proc.reacts_[0]]['N'][t - 1, r] + self.Km_vals[proc])
         mult = mult_reg * mult_mm
-        self.trans_p[proc] = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
-        self._order_1(proc, r, t)
+        transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
+
+        self._order_1(proc, r, t, transition_probability)
 
         for i in range(len(proc.regulating_species)):
             if proc.is_heterogeneous_K50[i]:  # Now compute metrics of heterogeneity (K50)
@@ -1083,17 +1090,19 @@ class SimulationMethodsMixin:
             new_Km_vals = self.Km_vals[proc] * (self.rtd[proc.reacts_[0]].asv[r][1, :] > 0)
             self._compute_Km_het_metrics(proc, new_Km_vals, t, r)
 
-    def _order_2(self, proc: Process, r: int, t: int):
+    def _order_2(self, proc: Process, r: int, t: int, transition_p: np.ndarray = None):
         """
         Determine the transition events for a 2nd order process `proc`
         in a single time step of an AbStochKin simulation. Then update the
         agent-state vector(s) `asv` accordingly.
         """
+        trans_p = transition_p if transition_p is not None else self.trans_p[proc]
+
         # Get random numbers (rn) and transition probabilities (tp)
         rn, tp = self.rtd[proc.reacts_[0]].get_vals_o2(self.rtd[proc.reacts_[1]],
                                                        r,
                                                        self.streams[r],
-                                                       self.trans_p[proc])
+                                                       trans_p)
 
         transition_events = rn < tp  # Determine all transition events in this time step
 
@@ -1128,9 +1137,9 @@ class SimulationMethodsMixin:
         """
         ratio = self.results[proc.regulating_species]['N'][t - 1, r] / self.K50_vals[proc]
         mult = (1 + proc.alpha * ratio ** proc.nH) / (1 + ratio ** proc.nH)
-        self.trans_p[proc] = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
+        transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
 
-        self._order_2(proc, r, t)
+        self._order_2(proc, r, t, transition_probability)
 
         if proc.is_heterogeneous_K50:  # Now compute metrics of heterogeneity (K50)
             new_K50_vals = self.K50_vals[proc] * (
@@ -1148,9 +1157,9 @@ class SimulationMethodsMixin:
         for i, sp in enumerate(proc.regulating_species):
             ratio = self.results[sp]['N'][t - 1, r] / self.K50_vals[proc][i]
             mult *= (1 + proc.alpha[i] * ratio ** proc.nH[i]) / (1 + ratio ** proc.nH[i])
-        self.trans_p[proc] = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
+        transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
 
-        self._order_2(proc, r, t)
+        self._order_2(proc, r, t, transition_probability)
 
         for i in range(len(proc.regulating_species)):
             if proc.is_heterogeneous_K50[i]:  # Now compute metrics of heterogeneity (K50)

--- a/abstochkin/_simulation_methods.py
+++ b/abstochkin/_simulation_methods.py
@@ -851,7 +851,7 @@ class SimulationMethodsMixin:
                     else:
                         self.algo_sequence.append(partial(self._order_0_reg, proc))
                 else:
-                    self.algo_sequence.append(partial(self._order_0, proc))
+                    self.algo_sequence.append(partial(self._order_0_base, proc))
             elif proc.order == 1:
                 if isinstance(proc, MichaelisMentenProcess):
                     self.algo_sequence.append(partial(self._order_1_mm, proc))
@@ -866,7 +866,7 @@ class SimulationMethodsMixin:
                     else:
                         self.algo_sequence.append(partial(self._order_1_reg, proc))
                 else:
-                    self.algo_sequence.append(partial(self._order_1, proc))
+                    self.algo_sequence.append(partial(self._order_1_base, proc))
             else:  # order 2
                 if isinstance(proc, RegulatedProcess):
                     if isinstance(proc.regulating_species, list):
@@ -874,7 +874,7 @@ class SimulationMethodsMixin:
                     else:
                         self.algo_sequence.append(partial(self._order_2_reg, proc))
                 else:
-                    self.algo_sequence.append(partial(self._order_2, proc))
+                    self.algo_sequence.append(partial(self._order_2_base, proc))
 
     def _parallel_run(self, num_workers=None):
         """
@@ -919,7 +919,7 @@ class SimulationMethodsMixin:
 
         self.progress_bar.update(1)
 
-    def _order_0(self, proc: Process, r: int, t: int, transition_p: float = None):
+    def _order_0_base(self, proc: Process, r: int, t: int, transition_p: float = None):
         """
         Assess if a transition event occurs. Then update the agent-state vector
         `asv` accordingly.
@@ -953,7 +953,7 @@ class SimulationMethodsMixin:
 
         transition_probability = proc.k * mult * self.dt
 
-        self._order_0(proc, r, t, transition_probability)
+        self._order_0_base(proc, r, t, transition_probability)
 
     def _order_0_reg_gt1(self, proc: RegulatedProcess, r: int, t: int):
         """
@@ -968,9 +968,9 @@ class SimulationMethodsMixin:
 
         transition_probability = proc.k * mult * self.dt
 
-        self._order_0(proc, r, t, transition_probability)
+        self._order_0_base(proc, r, t, transition_probability)
 
-    def _order_1(self, proc: Process, r: int, t: int, transition_p: np.ndarray = None):
+    def _order_1_base(self, proc: Process, r: int, t: int, transition_p: np.ndarray = None):
         """
         Determine the transition events for a 1st order process `proc`
         in a single time step of an AbStochKin simulation. Then update the
@@ -1022,7 +1022,7 @@ class SimulationMethodsMixin:
 
         transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
 
-        self._order_1(proc, r, t, transition_probability)
+        self._order_1_base(proc, r, t, transition_probability)
 
         if proc.is_heterogeneous_Km:  # Now compute metrics of heterogeneity (Km)
             new_Km_vals = self.Km_vals[proc] * (self.rtd[proc.reacts_[0]].asv[r][1, :] > 0)
@@ -1038,7 +1038,7 @@ class SimulationMethodsMixin:
         mult = (1 + proc.alpha * ratio ** proc.nH) / (1 + ratio ** proc.nH)
         transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
 
-        self._order_1(proc, r, t, transition_probability)
+        self._order_1_base(proc, r, t, transition_probability)
 
         if proc.is_heterogeneous_K50:  # Now compute metrics of heterogeneity (K50)
             new_K50_vals = self.K50_vals[proc] * (self.rtd[proc.reacts_[0]].asv[r][1, :] > 0)
@@ -1056,7 +1056,7 @@ class SimulationMethodsMixin:
             mult *= (1 + proc.alpha[i] * ratio ** proc.nH[i]) / (1 + ratio ** proc.nH[i])
         transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
 
-        self._order_1(proc, r, t, transition_probability)
+        self._order_1_base(proc, r, t, transition_probability)
 
         for i in range(len(proc.regulating_species)):
             if proc.is_heterogeneous_K50[i]:  # Now compute metrics of heterogeneity (K50)
@@ -1077,7 +1077,7 @@ class SimulationMethodsMixin:
         mult = mult_reg * mult_mm
         transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
 
-        self._order_1(proc, r, t, transition_probability)
+        self._order_1_base(proc, r, t, transition_probability)
 
         if proc.is_heterogeneous_K50:  # Now compute metrics of heterogeneity (K50)
             new_K50_vals = self.K50_vals[proc] * (self.rtd[proc.reacts_[0]].asv[r][1, :] > 0)
@@ -1103,7 +1103,7 @@ class SimulationMethodsMixin:
         mult = mult_reg * mult_mm
         transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
 
-        self._order_1(proc, r, t, transition_probability)
+        self._order_1_base(proc, r, t, transition_probability)
 
         for i in range(len(proc.regulating_species)):
             if proc.is_heterogeneous_K50[i]:  # Now compute metrics of heterogeneity (K50)
@@ -1114,7 +1114,7 @@ class SimulationMethodsMixin:
             new_Km_vals = self.Km_vals[proc] * (self.rtd[proc.reacts_[0]].asv[r][1, :] > 0)
             self._compute_Km_het_metrics(proc, new_Km_vals, t, r)
 
-    def _order_2(self, proc: Process, r: int, t: int, transition_p: np.ndarray = None):
+    def _order_2_base(self, proc: Process, r: int, t: int, transition_p: np.ndarray = None):
         """
         Determine the transition events for a 2nd order process `proc`
         in a single time step of an AbStochKin simulation. Then update the
@@ -1175,7 +1175,7 @@ class SimulationMethodsMixin:
         mult = (1 + proc.alpha * ratio ** proc.nH) / (1 + ratio ** proc.nH)
         transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
 
-        self._order_2(proc, r, t, transition_probability)
+        self._order_2_base(proc, r, t, transition_probability)
 
         if proc.is_heterogeneous_K50:  # Now compute metrics of heterogeneity (K50)
             new_K50_vals = self.K50_vals[proc] * (
@@ -1195,7 +1195,7 @@ class SimulationMethodsMixin:
             mult *= (1 + proc.alpha[i] * ratio ** proc.nH[i]) / (1 + ratio ** proc.nH[i])
         transition_probability = 1 - np.exp(-1 * self.k_vals[proc] * mult * self.dt)
 
-        self._order_2(proc, r, t, transition_probability)
+        self._order_2_base(proc, r, t, transition_probability)
 
         for i in range(len(proc.regulating_species)):
             if proc.is_heterogeneous_K50[i]:  # Now compute metrics of heterogeneity (K50)

--- a/abstochkin/_simulation_methods.py
+++ b/abstochkin/_simulation_methods.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/abstochkin/_simulation_methods.py
+++ b/abstochkin/_simulation_methods.py
@@ -923,6 +923,18 @@ class SimulationMethodsMixin:
         """
         Assess if a transition event occurs. Then update the agent-state vector
         `asv` accordingly.
+
+        Parameters
+        ----------
+        proc : Process
+            The process object for which the transition is being assessed.
+        r : int
+            The repetition index of the simulation.
+        t : int
+            The time step index of the simulation.
+        transition_p : float, optional
+            The transition probability to use for this event.
+            If `None`, defaults to `self.trans_p[proc]`.
         """
         trans_p = transition_p if transition_p is not None else self.trans_p[proc]
 
@@ -963,6 +975,18 @@ class SimulationMethodsMixin:
         Determine the transition events for a 1st order process `proc`
         in a single time step of an AbStochKin simulation. Then update the
         agent-state vector `asv` accordingly.
+
+        Parameters
+        ----------
+        proc : Process
+            The process object for which the transition is being assessed.
+        r : int
+            The repetition index of the simulation.
+        t : int
+            The time step index of the simulation.
+        transition_p : np.ndarray, optional
+            The transition probability to use for this event.
+            If `None`, defaults to `self.trans_p[proc]`.
         """
         trans_p = transition_p if transition_p is not None else self.trans_p[proc]
 
@@ -1095,6 +1119,18 @@ class SimulationMethodsMixin:
         Determine the transition events for a 2nd order process `proc`
         in a single time step of an AbStochKin simulation. Then update the
         agent-state vector(s) `asv` accordingly.
+
+        Parameters
+        ----------
+        proc : Process
+            The process object for which the transition is being assessed.
+        r : int
+            The repetition index of the simulation.
+        t : int
+            The time step index of the simulation.
+        transition_p : np.ndarray, optional
+            The transition probability to use for this event.
+            If `None`, defaults to `self.trans_p[proc]`.
         """
         trans_p = transition_p if transition_p is not None else self.trans_p[proc]
 

--- a/abstochkin/agentstatedata.py
+++ b/abstochkin/agentstatedata.py
@@ -3,7 +3,7 @@ Class for storing the state of all agents of a certain species during an
 AbStochKin simulation.
 """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/abstochkin/agentstatedata.py
+++ b/abstochkin/agentstatedata.py
@@ -69,10 +69,17 @@ class AgentStateData:
     def __post_init__(self):
         # Set up initial (t=0) agent-state vector (asv):
         self.asv_ini = np.concatenate(
-            (np.ones(shape=(2, self.p_init), dtype=np.int8),
-             np.full(shape=(2, self.max_agents - self.p_init),
-                     fill_value=self.fill_state,
-                     dtype=np.int8)),
+            (
+                np.ones(
+                    shape=(2, self.p_init),
+                    dtype=np.int8
+                ),
+                np.full(
+                    shape=(2, self.max_agents - self.p_init),
+                    fill_value=self.fill_state,
+                    dtype=np.int8
+                )
+            ),
             axis=1
         )
 

--- a/abstochkin/base.py
+++ b/abstochkin/base.py
@@ -18,7 +18,7 @@ Example
 >>> # documented in the class `Simulation`.
 
 """
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/abstochkin/de_calcs.py
+++ b/abstochkin/de_calcs.py
@@ -5,7 +5,7 @@ describing the system and obtain a numerical solution.
 Try to get the system's fixed points numerically and symbolically.
 """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/abstochkin/graphing.py
+++ b/abstochkin/graphing.py
@@ -1,6 +1,6 @@
 """  Graphing for AbStochKin simulations. """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -107,7 +107,7 @@ class Graph:
                   de_data,
                   *,
                   num_pts: int = 1000,
-                  species: list[str] | tuple[str] = (),
+                  species: list[str] | tuple[str] | set[str] | None = None,
                   show_plot: bool = True,
                   ax_loc: tuple = ()) -> Self:
         """
@@ -124,7 +124,7 @@ class Graph:
                  Number of points used to calculate DE curves at.
                  Used to approximate a smooth/continuous curve.
 
-        species : sequence of strings, default: (), optional
+        species : sequence of strings, default: None, optional
                  An iterable sequence of strings specifying the species
                  names to plot. If no species are specified (the default),
                  then all species trajectories are plotted.
@@ -140,7 +140,7 @@ class Graph:
                 a 1-D array. For figures with multiple rows and columns of
                 subplots, a 2-D tuple is needed.
         """
-        species = list(de_data.odes.keys()) if len(species) == 0 else species
+        species = list(de_data.odes.keys()) if not species else species
         # t, y = ode_sol.t, ode_sol.y.T  # values at precomputed time pts
         t = np.linspace(de_data.odes_sol.t[0], de_data.odes_sol.t[-1],
                         num_pts)  # time points for obtaining...
@@ -193,13 +193,13 @@ class Graph:
                           time,
                           data,
                           *,
-                          species: list[str] | tuple[str] = (),
+                          species: list[str] | tuple[str] | set[str] | None = None,
                           show_plot: bool = True,
                           ax_loc: tuple = ()
                           ) -> Self:
         """ Graph simulation time trajectories. """
         self.setup_spines_ticks(ax_loc)
-        species = list(data.keys()) if len(species) == 0 else species
+        species = list(data.keys()) if not species else species
 
         if self.backend == 'matplotlib':
             axs = self.ax if len(ax_loc) == 0 else self.ax[ax_loc]
@@ -212,7 +212,7 @@ class Graph:
                         axs.plot(time, traj, linewidth=0.25)
 
             axs.set(title="ABK trajectories")
-            axs.set(xlabel=f"$t$ (sec)", ylabel="$N$")
+            axs.set(xlabel="$t$ (sec)", ylabel="$N$")
             # axs.legend(loc='best')
 
             if show_plot:
@@ -233,7 +233,7 @@ class Graph:
                             )
                         )
             self.fig.update_layout(
-                xaxis=dict(title=f"$t \\; (sec)$",
+                xaxis=dict(title="$t \\; (sec)$",
                            range=[-0.01 * time[-1], time[-1]]),
                 yaxis=dict(title="$N$")
             )
@@ -247,7 +247,7 @@ class Graph:
                      time,
                      data,
                      *,
-                     species: list[str] | tuple[str] = (),
+                     species: list[str] | tuple[str] | set[str] | None = None,
                      show_plot: bool = True,
                      ax_loc: tuple = ()) -> Self:
         """
@@ -255,7 +255,7 @@ class Graph:
         1-standard-deviation envelopes.
         """
         self.setup_spines_ticks(ax_loc)
-        species = list(data.keys()) if len(species) == 0 else species
+        species = list(data.keys()) if not species else species
 
         if self.backend == 'matplotlib':
             axs = self.ax if len(ax_loc) == 0 else self.ax[ax_loc]
@@ -314,7 +314,7 @@ class Graph:
                     )
 
             self.fig.update_layout(
-                xaxis=dict(title=f"$t \\; (sec)$",
+                xaxis=dict(title="$t \\; (sec)$",
                            range=[-0.01 * time[-1], time[-1]]),
                 yaxis=dict(title="$N$")
             )
@@ -328,12 +328,12 @@ class Graph:
                  time,
                  data,
                  *,
-                 species: list[str] | tuple[str] = (),
+                 species: list[str] | tuple[str] | set[str] | None = None,
                  show_plot: bool = True,
                  ax_loc: tuple = ()) -> Self:
         """ Graph the coefficient of variation. """
         self.setup_spines_ticks(ax_loc)
-        species = list(data.keys()) if len(species) == 0 else species
+        species = list(data.keys()) if not species else species
 
         if self.backend == "matplotlib":
             axs = self.ax if len(ax_loc) == 0 else self.ax[ax_loc]
@@ -346,7 +346,7 @@ class Graph:
                              label=f"${sp}_{{Poisson}}$", color=(0.5, 0.5, 0.5))
 
             axs.set(title="Coefficient of Variation, $\\eta$")
-            axs.set(xlabel=f"$t$ (sec)", ylabel="$\\eta$")
+            axs.set(xlabel="$t$ (sec)", ylabel="$\\eta$")
             axs.legend(loc='upper right')
 
             if show_plot:
@@ -375,7 +375,7 @@ class Graph:
 
             self.fig.update_layout(
                 title="Coefficient of Variation",
-                xaxis=dict(title=f"$t \\; (sec)$",
+                xaxis=dict(title="$t \\; (sec)$",
                            range=[-0.01 * time[-1], time[-1]]),
                 yaxis=dict(title="$\\eta$")
             )
@@ -416,7 +416,7 @@ class Graph:
             axs.tick_params(axis='y', labelcolor='blue')
 
             axs.set(title=title + (f"$, {proc_str[1]}$" if proc_str[1] != "" else ""),
-                    xlabel=f"$t$ (sec)")
+                    xlabel="$t$ (sec)")
 
             if het_attr == 'Km':
                 axs.set_ylabel("$K_m$", color='blue')
@@ -488,7 +488,7 @@ class Graph:
 
             self.fig.update_layout(
                 title=title + (f"$, {proc_str[1]}$" if proc_str[1] != "" else ""),
-                xaxis=dict(title=f"$t \\; (sec)$",
+                xaxis=dict(title="$t \\; (sec)$",
                            range=[-0.01 * time[-1], time[-1]]),
                 yaxis=dict(title="$K_m$" if het_attr == "Km" else "$K_{50}$" if het_attr == "K50" else f"${het_attr}$",
                            color="blue",
@@ -516,7 +516,7 @@ class Graph:
                     x=time.tolist(),
                     y=proc_data['psi_avg'],
                     mode='lines',
-                    name=f"$<\\psi>$",
+                    name="$<\\psi>$",
                     line=dict(width=2, color='red'),
                 )
             )
@@ -526,7 +526,7 @@ class Graph:
                     x=time.tolist(),
                     y=proc_data['psi_avg'] + proc_data['psi_std'],
                     mode='lines',
-                    name=f"$<\\psi> + \\sigma$",
+                    name="$<\\psi> + \\sigma$",
                     line=dict(width=0),
                     showlegend=False
                 )
@@ -537,7 +537,7 @@ class Graph:
                     x=time.tolist(),
                     y=proc_data['psi_avg'] - proc_data['psi_std'],
                     mode='lines',
-                    name=f"$<\\psi> + \\sigma$",
+                    name="$<\\psi> + \\sigma$",
                     line=dict(width=0),
                     fill='tonexty',
                     showlegend=False
@@ -546,7 +546,7 @@ class Graph:
 
             self.fig2.update_layout(
                 title=title + (f"$, {proc_str[1]}$" if proc_str[1] != "" else ""),
-                xaxis=dict(title=f"$t \\; (sec)$",
+                xaxis=dict(title="$t \\; (sec)$",
                            range=[-0.01 * time[-1], time[-1]]),
                 yaxis=dict(title="$\\psi$",
                            color="red",

--- a/abstochkin/het_calcs.py
+++ b/abstochkin/het_calcs.py
@@ -1,6 +1,6 @@
 """ Some functions for calculating metrics of population heterogeneity. """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/abstochkin/simulation.py
+++ b/abstochkin/simulation.py
@@ -10,7 +10,7 @@ The class `AgentStateData` is used by a `Simulation`
 object to store and handle some of the necessary runtime data.
 """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -147,6 +147,7 @@ class Simulation(SimulationMethodsMixin):
         self.max_agents = max_agents
         self.max_agents_multiplier = max_agents_multiplier
         self.time_unit = time_unit
+        self.graph_backend: Literal['matplotlib', 'plotly'] = graph_backend
 
         self.all_species, self._procs_by_reactant, self._procs_by_product = \
             update_all_species(tuple(self.processes))
@@ -338,7 +339,7 @@ class Simulation(SimulationMethodsMixin):
                                 graph_het = Graph(backend=self.graph_backend)
                                 extra_str = f"\\textrm{{{proc.regulation_type[i]} by }}" \
                                             f"{proc.regulating_species[i]}, " \
-                                            f"K_{{50}}={proc.K50[i]}"
+                                            f"K_{{50}}={proc.K50[i]}" # type: ignore
                                 graph_het.plot_het_metrics(self.time,
                                                            (str(proc), extra_str),
                                                            self.K50_het_metrics[proc][i],

--- a/abstochkin/utils.py
+++ b/abstochkin/utils.py
@@ -5,7 +5,7 @@ when comparing time series data, and performing unit conversion of
 kinetic parameters.
 """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/docs/simulation_architecture.mmd
+++ b/docs/simulation_architecture.mmd
@@ -1,0 +1,96 @@
+%%{init: {
+  'theme': 'base',
+  'themeVariables': {
+    'primaryColor': '#2C3E50',
+    'edgeLabelBackground': '#ffffff',
+    'tertiaryColor': '#ecf0f1',
+    'lineColor': '#7f8c8d'
+  }
+}}%%
+
+flowchart TB
+    %% --- STYLE DEFINITIONS ---
+    classDef controller fill:#2C3E50,stroke:#2C3E50,stroke-width:2px,color:#fff,font-weight:bold;
+    classDef process fill:#FFFFFF,stroke:#34495E,stroke-width:2px,color:#2C3E50,rx:5,ry:5;
+    classDef data fill:#EBF5FB,stroke:#3498DB,stroke-width:2px,color:#2C3E50,stroke-dasharray: 5 5;
+    classDef math fill:#FDF2E9,stroke:#D35400,stroke-width:2px,color:#D35400;
+    classDef result fill:#EAFAF1,stroke:#2ECC71,stroke-width:2px,color:#27AE60;
+
+    %% Style for the invisible layout wrapper
+    classDef container fill:none,stroke:none;
+
+    %% --- MAIN SIMULATION FLOW (Horizontal) ---
+    subgraph ExecutionFlow [" "]
+        direction LR
+
+        %% 1. SETUP
+        subgraph Setup ["🛠️ Simulation Setup"]
+            direction TB
+            A[/"fa:fa-cogs Simulation Class"\]:::controller
+            B(Process List):::process
+            C(Initial Pop.):::data
+            D(Params):::data
+
+            A -- Initializes --> B
+            A -- Initializes --> C & D
+        end
+
+        %% 2. MATH
+        subgraph Math ["🧮 ODE & Heterogeneity"]
+            direction TB
+            J["DEcalcs Class"]:::math
+            K("fa:fa-chart-line ODE Solver"):::math
+            L["het_calcs Module"]:::math
+            M("Heterogeneity Metrics"):::math
+
+            J -- Solves --> K
+            K -. Feedback .-> A
+            L -- Calculates --> M
+        end
+
+        %% 3. LOOP
+        subgraph Loop ["🔄 Core Loop"]
+            direction TB
+            E{"Algorithm Sequence"}:::process
+            F["Time Steps"]:::process
+            G["fa:fa-play Process Functions"]:::process
+
+            B -- Defines --> E
+            E -- Iterates --> F
+            F -- Step --> G
+        end
+
+        %% 4. STATE MANAGEMENT
+        subgraph StateMgmt ["💾 State Execution"]
+            direction TB
+            I[("AgentStateData")]:::data
+            H("Agent-State Vectors"):::data
+
+            G -- Updates --> H
+            I -- Manages --> H
+            I -. Provides State .-> G
+        end
+    end
+
+    %% --- RESULTS (Bottom Center) ---
+    subgraph Output ["📊 Results Analysis"]
+        direction TB
+        N("fa:fa-database Results"):::result
+        O["fa:fa-chart-bar Graph Class"]:::result
+
+        N -- Visualized by --> O
+    end
+
+    %% Apply invisible style to the wrapper
+    class ExecutionFlow container;
+
+    %% --- CROSS CONNECTIONS ---
+    %% Flow Logic
+    A --> J
+    A --> L
+    A ====> E
+    M --> G
+
+    %% Connections to Results (This centers the Output subgraph)
+    A ----> N
+    H -- Aggregates --> N

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent",
   "Topic :: Scientific/Engineering",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,10 @@ plotly = [
 Homepage = "https://github.com/alexplaka/AbStochKin"
 Documentation = "https://alexplaka.github.io/AbStochKin"
 Issues = "https://github.com/alexplaka/AbStochKin/issues"
+
+[dependency-groups]
+dev = [
+    "coverage>=7.13.0",
+    "marimo>=0.18.4",
+    "pyzmq>=27.1.0",
+]

--- a/tests/het_predictions_o1.py
+++ b/tests/het_predictions_o1.py
@@ -14,7 +14,7 @@ References
 - See code: https://github.com/alexplaka/ABK/blob/master/Heterogeneous_Pops/1_BasicKinetics/1st%20order/Distinct_Subspecies/Het_o1_Predict.m
 """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test__simulation_methods.py
+++ b/tests/test__simulation_methods.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_de_calcs.py
+++ b/tests/test_de_calcs.py
@@ -1,6 +1,6 @@
 """ Test the `DEcalcs` class (used for deterministic calculations). """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_het_calcs.py
+++ b/tests/test_het_calcs.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,6 +1,6 @@
 """ Test the Process class and its subclasses. """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_sim_birth_death.py
+++ b/tests/test_sim_birth_death.py
@@ -7,7 +7,7 @@ This way, the statistics of the simulated trajectories can be
 compared to deterministic (ODE and CME) predictions.
 """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_sim_order0.py
+++ b/tests/test_sim_order0.py
@@ -3,7 +3,7 @@ Test running a simulation of a 0th order process:  -> A
 Test running a simulation of a regulated 0th order process:  -> A
 """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_sim_order1.py
+++ b/tests/test_sim_order1.py
@@ -11,7 +11,7 @@ of species A with respect to the rate constant `k`:
     - Heterogeneous population: normally-distributed k values
 """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_sim_order1_MM.py
+++ b/tests/test_sim_order1_MM.py
@@ -10,7 +10,7 @@ of species A with respect to the rate constant `Km`:
     - Heterogeneous population: normally-distributed `Km` values
 """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_sim_order1_reg.py
+++ b/tests/test_sim_order1_reg.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_sim_order1_reg_MM.py
+++ b/tests/test_sim_order1_reg_MM.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_sim_order2.py
+++ b/tests/test_sim_order2.py
@@ -9,7 +9,7 @@ inter-agent interactions wrt rate constant `k`:
     - Heterogeneous population: normally-distributed k values
 """
 
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_sim_order2_reg.py
+++ b/tests/test_sim_order2_reg.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_sim_reversible.py
+++ b/tests/test_sim_reversible.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025, Alex Plakantonakis.
+#  Copyright (c) 2024-2026, Alex Plakantonakis.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
One of the simulation parameters was not thread safe. This PR fixes this issue.

Key Changes:

- Refactored regulated and Michaelis-Menten process methods to calculate transition probabilities in local variables instead of modifying the shared `self.trans_p` dictionary
- Added optional transition_p parameter to _order_0, _order_1, and _order_2 methods to accept pre-calculated transition probabilities
- Added Mermaid diagram documenting the simulation architecture
